### PR TITLE
Display correct percentages for the mutation status checkboxes

### DIFF
--- a/src/components/SignalMutationMapper.tsx
+++ b/src/components/SignalMutationMapper.tsx
@@ -15,6 +15,7 @@ import {
 
 import {
     CANCER_TYPE_FILTER_ID,
+    CANCER_TYPE_IGNORE_MUTATION_STATUS_FILTER_TYPE,
     findCancerTypeFilter,
     findMutationStatusFilter,
     findMutationTypeFilter,
@@ -268,8 +269,11 @@ export class SignalMutationMapper extends ReactMutationMapper<ISignalMutationMap
             values: [MutationStatusFilterValue.BIALLELIC_PATHOGENIC_GERMLINE]
         };
 
-        const filtersWithoutMutationStatusFilter =
-            this.store.dataStore.dataFilters.filter(f => f.id !== MUTATION_STATUS_FILTER_ID);
+        const filtersWithoutMutationStatusFilter = this.store.dataStore.dataFilters
+            .filter(f => f.id !== MUTATION_STATUS_FILTER_ID)
+            // we cannot directly apply the default cancer type filter, we need to ignore mutation status
+            .map(f => f.id === CANCER_TYPE_FILTER_ID ?
+                {...f, type: CANCER_TYPE_IGNORE_MUTATION_STATUS_FILTER_TYPE}: f);
 
         // apply filters excluding the mutation status filter
         // this prevents ratio of unchecked mutation status values from being calculated as zero

--- a/src/util/FilterUtils.ts
+++ b/src/util/FilterUtils.ts
@@ -15,6 +15,7 @@ export const PENETRANCE_FILTER_ID = "_signalPenetranceFilter_"
 export const HUGO_SYMBOL_FILTER_TYPE = "signalHugoSymbol";
 export const MUTATION_STATUS_FILTER_TYPE = "signalMutationStatus";
 export const MUTATION_COUNT_FILTER_TYPE = "signalMutationCount";
+export const CANCER_TYPE_IGNORE_MUTATION_STATUS_FILTER_TYPE = "signalCancerTypeIgnoreMutationStatus";
 export const PENETRANCE_FILTER_TYPE = "signalPenetrance"
 
 export enum MutationStatusFilterValue {


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8061

Note that there are still known cancer type filter related issues. This one only fixes the percentages shown when cancer type filter is applied.