### PR TITLE
Remove link out icon from the Hgvsg column

### DIFF
--- a/src/components/ColumnRenderHelper.tsx
+++ b/src/components/ColumnRenderHelper.tsx
@@ -23,7 +23,7 @@ export function renderPenetrance(cellProps: any)
 
 export function renderHgvsg(cellProps: any)
 {
-    const constructLink = (hgvsg: string, content: JSX.Element) => <Link to={`/variant/${hgvsg}`}>{content}</Link>;
+    const constructLink = (hgvsg: string) => <Link to={`/variant/${hgvsg}`}>{hgvsg}</Link>;
 
     return (
         <Hgvsg


### PR DESCRIPTION
We decided to remove the link out icon from the HGVSg column since it's an internal link.