### PR TITLE
Remove certain annotations for germline mutations

### DIFF
--- a/src/components/ColumnHeaderHelper.tsx
+++ b/src/components/ColumnHeaderHelper.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {ColumnHeader} from "react-mutation-mapper";
+import {ColumnHeader, MutationColumn} from "react-mutation-mapper";
 
 export enum ColumnId {
     HUGO_SYMBOL = "hugoSymbol",
@@ -56,4 +56,5 @@ export const HEADER_COMPONENT: {[id: string] : JSX.Element} = {
         />
     ),
     [ColumnId.SAMPLE_COUNT]: <ColumnHeader headerContent={<span className="text-wrap"># Samples</span>} />,
+    [MutationColumn.ANNOTATION]: <ColumnHeader headerContent={<span className="pull-left">Somatic Annotation</span>} />,
 };

--- a/src/components/ColumnRenderHelper.tsx
+++ b/src/components/ColumnRenderHelper.tsx
@@ -1,5 +1,6 @@
+import {SignalMutationStatus} from "cbioportal-utils";
 import * as React from "react";
-import {Hgvsg} from "react-mutation-mapper";
+import {Hgvsg, MutationStatus} from "react-mutation-mapper";
 import {Link} from "react-router-dom";
 
 import {FrequencyCell} from "cbioportal-frontend-commons";
@@ -37,6 +38,29 @@ export function renderHgvsg(cellProps: any)
             mutation={cellProps.original}
             constructLink={constructLink}
             disableTooltip={true}
+        />
+    );
+}
+
+export function renderMutationStatus(cellProps: any)
+{
+    return (
+        <MutationStatus
+            value={cellProps.value}
+            enableTooltip={false}
+            displayValueMap={{
+                [SignalMutationStatus.SOMATIC.toLowerCase()]:
+                SignalMutationStatus.SOMATIC,
+                [SignalMutationStatus.PATHOGENIC_GERMLINE.toLowerCase()]:
+                SignalMutationStatus.PATHOGENIC_GERMLINE,
+                [SignalMutationStatus.BENIGN_GERMLINE.toLowerCase()]:
+                SignalMutationStatus.BENIGN_GERMLINE,
+            }}
+            styleMap={{
+                [SignalMutationStatus.PATHOGENIC_GERMLINE.toLowerCase()]: {
+                    background: "#FFA963"
+                }
+            }}
         />
     );
 }

--- a/src/components/MutationMapper.tsx
+++ b/src/components/MutationMapper.tsx
@@ -11,6 +11,7 @@ import {computed} from "mobx";
 import {observer} from "mobx-react";
 import * as React from "react";
 import {
+    Annotation,
     CancerTypeFilter,
     ColumnSortDirection,
     DataFilter,
@@ -241,7 +242,10 @@ class MutationMapper extends React.Component<IMutationMapperProps> {
                         Header: HEADER_COMPONENT[ColumnId.PERCENT_BIALLELIC],
                         sortMethod: defaultSortMethod
                     },
-                    MUTATION_COLUMNS_DEFINITION[MutationColumn.ANNOTATION],
+                    {
+                        ...MUTATION_COLUMNS_DEFINITION[MutationColumn.ANNOTATION],
+                        Cell: this.renderAnnotation
+                    },
                     {
                         // override default HGVSg column to customize the link
                         ...MUTATION_COLUMNS_DEFINITION[MutationColumn.HGVSG],
@@ -355,6 +359,7 @@ class MutationMapper extends React.Component<IMutationMapperProps> {
             this.showSomaticPercent
         );
     }
+
     private get mutationCountFilter() {
         return {
             type: MUTATION_COUNT_FILTER_TYPE,
@@ -420,6 +425,25 @@ class MutationMapper extends React.Component<IMutationMapperProps> {
         return props.isExpanded ?
             <i className="fa fa-minus-circle" /> :
             <i className="fa fa-plus-circle" />;
+    }
+
+    @autobind
+    private renderAnnotation(column: any) {
+        const mutation: IExtendedSignalMutation = column.original;
+
+        // disable certain annotations for germline mutations
+        const props = this.signalMutationMapper ? {
+            ...this.signalMutationMapper.defaultAnnotationColumnProps,
+            mutation: mutation as any,
+            enableOncoKb: isSomaticMutation(mutation) ?
+                this.signalMutationMapper.defaultAnnotationColumnProps.enableOncoKb : false,
+            enableHotspot: isSomaticMutation(mutation) ?
+                this.signalMutationMapper.defaultAnnotationColumnProps.enableHotspot : false,
+            enableMyCancerGenome: isSomaticMutation(mutation) ?
+                this.signalMutationMapper.defaultAnnotationColumnProps.enableMyCancerGenome : false,
+        }: undefined;
+
+        return props ? <Annotation {...props} />: undefined;
     }
 
     @autobind

--- a/src/components/MutationMapper.tsx
+++ b/src/components/MutationMapper.tsx
@@ -19,7 +19,6 @@ import {
     defaultSortMethod,
     MUTATION_COLUMNS_DEFINITION,
     MutationColumn,
-    MutationStatus,
     ProteinChange,
     TrackName
 } from "react-mutation-mapper";
@@ -46,7 +45,7 @@ import {
 } from "../util/MutationDataUtils";
 import {loaderWithText} from "../util/StatusHelper";
 import {ColumnId, HEADER_COMPONENT} from "./ColumnHeaderHelper";
-import {renderCancerType, renderHgvsg, renderPenetrance, renderPercentage} from "./ColumnRenderHelper";
+import {renderCancerType, renderHgvsg, renderMutationStatus, renderPenetrance, renderPercentage} from "./ColumnRenderHelper";
 import {sortPenetrance} from "./GeneFrequencyTable";
 import MutationTumorTypeFrequencyDecomposition from "./MutationTumorTypeFrequencyDecomposition";
 import SignalMutationMapper from "./SignalMutationMapper";
@@ -185,24 +184,7 @@ class MutationMapper extends React.Component<IMutationMapperProps> {
                         ...MUTATION_COLUMNS_DEFINITION[MutationColumn.MUTATION_STATUS],
                         accessor: mutationStatusAccessor,
                         width: 200,
-                        Cell: (column: any) =>
-                            <MutationStatus
-                                value={column.value}
-                                enableTooltip={false}
-                                displayValueMap={{
-                                    [SignalMutationStatus.SOMATIC.toLowerCase()]:
-                                        SignalMutationStatus.SOMATIC,
-                                    [SignalMutationStatus.PATHOGENIC_GERMLINE.toLowerCase()]:
-                                        SignalMutationStatus.PATHOGENIC_GERMLINE,
-                                    [SignalMutationStatus.BENIGN_GERMLINE.toLowerCase()]:
-                                        SignalMutationStatus.BENIGN_GERMLINE,
-                                }}
-                                styleMap={{
-                                    [SignalMutationStatus.PATHOGENIC_GERMLINE.toLowerCase()]: {
-                                        background: "#FFA963"
-                                    }
-                                }}
-                            />
+                        Cell: renderMutationStatus
                     },
                     {
                         id: ColumnId.PENETRANCE,
@@ -244,7 +226,11 @@ class MutationMapper extends React.Component<IMutationMapperProps> {
                     },
                     {
                         ...MUTATION_COLUMNS_DEFINITION[MutationColumn.ANNOTATION],
-                        Cell: this.renderAnnotation
+                        Header: HEADER_COMPONENT[MutationColumn.ANNOTATION],
+                        Cell: this.renderAnnotation,
+                        // TODO disable sort for now due to an undesired sort behavior
+                        //  (see https://github.com/cBioPortal/cbioportal/issues/8247)
+                        sortable: false
                     },
                     {
                         // override default HGVSg column to customize the link
@@ -428,8 +414,8 @@ class MutationMapper extends React.Component<IMutationMapperProps> {
     }
 
     @autobind
-    private renderAnnotation(column: any) {
-        const mutation: IExtendedSignalMutation = column.original;
+    private renderAnnotation(cellProps: any) {
+        const mutation: IExtendedSignalMutation = cellProps.original;
 
         // disable certain annotations for germline mutations
         const props = this.signalMutationMapper ? {

--- a/src/components/SignalMutationMapper.tsx
+++ b/src/components/SignalMutationMapper.tsx
@@ -246,6 +246,24 @@ export class SignalMutationMapper extends ReactMutationMapper<ISignalMutationMap
         ): info;
     }
 
+    public get defaultAnnotationColumnProps() {
+        // TODO most of this code is duplicated from react-mutation-mapper
+        //  we should make the default props accessible if possible
+        return {
+            enableOncoKb: true,
+            enableHotspot: true,
+            enableCivic: this.props.enableCivic || false,
+            enableMyCancerGenome: true,
+            hotspotData: this.store.indexedHotspotData,
+            oncoKbData: this.store.oncoKbData,
+            oncoKbCancerGenes: this.store.oncoKbCancerGenes,
+            usingPublicOncoKbInstance: this.store.usingPublicOncoKbInstance,
+            pubMedCache: this.pubMedCache,
+            civicGenes: this.store.civicGenes,
+            civicVariants: this.store.civicVariants
+        };
+    }
+
     @computed
     public get mutationRatesByMutationStatus() {
         // TODO pick only likely driver ones, not all somatic mutations


### PR DESCRIPTION
Related to #78

- Rename `Annotation` to `Somatic Annotation`
- Remove annotations (except Civic) for germline mutations
- Disable sort for annotation column for no. It does not behave as desired when some of the annotations are disabled (see cBioPortal/cbioportal#8247)