### PR TITLE
Add Cancer Type column, filter out zero frequency tumors

### DIFF
--- a/src/components/ColumnHeaderHelper.tsx
+++ b/src/components/ColumnHeaderHelper.tsx
@@ -10,6 +10,7 @@ export enum ColumnId {
     GERMLINE = "germline",
     PERCENT_BIALLELIC = "percentBialleic",
     MUTATION_PERCENT = "mutationPercent",
+    CANCER_TYPE = "cancerType",
     SAMPLE_COUNT = "sampleCount"
 }
 
@@ -49,5 +50,10 @@ export const HEADER_COMPONENT: {[id: string] : JSX.Element} = {
         />
     ),
     [ColumnId.MUTATION_PERCENT]: <ColumnHeader headerContent={<span className="pull-right mr-3">% Prevalence</span>} />,
+    [ColumnId.CANCER_TYPE]: (
+        <ColumnHeader
+            headerContent={<span className="pull-left">Cancer Type</span>}
+        />
+    ),
     [ColumnId.SAMPLE_COUNT]: <ColumnHeader headerContent={<span className="text-wrap"># Samples</span>} />,
 };

--- a/src/components/ColumnRenderHelper.tsx
+++ b/src/components/ColumnRenderHelper.tsx
@@ -12,6 +12,13 @@ export function renderPercentage(cellProps: any)
     );
 }
 
+export function renderCancerType(cellProps: any)
+{
+    const tumorTypes: string[] = cellProps.value;
+
+    return <span>{tumorTypes.join(", ")}</span>;
+}
+
 export function renderPenetrance(cellProps: any)
 {
     return (

--- a/src/components/MutationTumorTypeFrequencyDecomposition.tsx
+++ b/src/components/MutationTumorTypeFrequencyDecomposition.tsx
@@ -43,7 +43,8 @@ class MutationTumorTypeFrequencyDecomposition extends React.Component<ITumorType
 
     @action.bound
     private handleDataLoad(frequencies: ISignalTumorTypeDecomposition[]) {
-        this.data = frequencies;
+        // filter out cancer types with zero frequency
+        this.data = frequencies.filter(f => f.frequency && f.frequency > 0);
         this.status = 'complete';
     }
 


### PR DESCRIPTION
Related to #66

- Add a new `Cancer Type` column to the mutation table listing all tumor types with non zero frequencies (except Unknown and Other)
- Remove tumor types with zero frequencies from the sub tumor type table. Note that variant page still lists all available tumor types, not sure if we want to update that one as well.