### PR TITLE
Improve landscape plot tooltip

### DIFF
--- a/src/components/LandscapePlot.tsx
+++ b/src/components/LandscapePlot.tsx
@@ -1,12 +1,12 @@
 import autobind from "autobind-decorator";
 import {CBIOPORTAL_VICTORY_THEME, ScatterPlot} from "cbioportal-frontend-commons";
+import {ISignalTumorTypeFrequencySummary, SignalMutationStatus} from "cbioportal-utils";
 import _ from "lodash";
 import {computed} from "mobx";
 import {observer} from "mobx-react";
 import * as React from "react";
 import { Link } from 'react-router-dom';
 
-import {ISignalTumorTypeFrequencySummary} from "cbioportal-utils";
 import GeneFrequencyStore from "../store/GeneFrequencyStore";
 import {
     dataPointSize,
@@ -206,12 +206,44 @@ class LandscapePlot extends React.Component<ILandscapePlotProps>
             sampleCount
         } = datum.datum;
 
+        const totalSampleCount = this.props.frequencyStore
+            .geneFrequencySummaryData
+            .find(d => d.hugoSymbol === hugoSymbol)?.sampleCount;
+
+        const pathogenicGermlineCount = _.round((sampleCount * (pathogenicGermlineFreq || 0)));
+        const pathogenicGermlineRatio = pathogenicGermlineFreq !== undefined ?
+            `${pathogenicGermlineCount} out of ${sampleCount} samples`: undefined
+
+        // TODO these numbers do not always match
+        // const biallelicCount = _.round(pathogenicGermlineCount * (percentBiallelicFreq || 0));
+        // const biallelicRatio = pathogenicGermlineFreq !== undefined ?
+        //     `${biallelicCount} out of ${pathogenicGermlineCount} samples`: undefined
+
         return (
             <>
-                <div>Hugo Symbol: <Link to={`/gene/${hugoSymbol}`}>{hugoSymbol}</Link></div>
-                <div>Tumor Type: <Link to={`/gene/${hugoSymbol}?cancerType=${tumorType}`}>{tumorType}</Link> ({sampleCount})</div>
-                <div>% Pathogenic Germline: <strong>{pathogenicGermline}</strong></div>
-                <div>% Biallelic: <strong>{percentBiallelic}</strong></div>
+                <div>
+                    Hugo Symbol:{' '}
+                    <Link to={`/gene/${hugoSymbol}`}>{hugoSymbol}</Link>{' '}
+                    ({totalSampleCount} total samples)
+                </div>
+                <div>
+                    Tumor Type:{' '}
+                    <Link to={`/gene/${hugoSymbol}?cancerType=${tumorType}`}>{tumorType}</Link>{' '}
+                    ({sampleCount} samples)
+                </div>
+                <div>
+                    Pathogenic Germline:{' '}
+                    <Link to={`/gene/${hugoSymbol}?cancerType=${tumorType}&mutationStatus=${SignalMutationStatus.PATHOGENIC_GERMLINE}`}>
+                        {pathogenicGermline}%
+                    </Link>{' '}
+                    ({pathogenicGermlineRatio})
+                </div>
+                <div>
+                    Biallelic:{' '}
+                    <Link to={`/gene/${hugoSymbol}?cancerType=${tumorType}&mutationStatus=${SignalMutationStatus.BIALLELIC_PATHOGENIC_GERMLINE}`}>
+                        {percentBiallelic}%
+                    </Link>
+                </div>
             </>
         );
     }

--- a/src/components/MutationMapper.tsx
+++ b/src/components/MutationMapper.tsx
@@ -59,6 +59,7 @@ interface IMutationMapperProps
     data: IExtendedSignalMutation[];
     hugoSymbol: string;
     cancerTypes?: string[];
+    mutationStatuses?: string[];
     ensemblGene?: IEnsemblGene;
 }
 
@@ -123,7 +124,7 @@ class MutationMapper extends React.Component<IMutationMapperProps> {
         const filters: DataFilter[] = [{
             id: MUTATION_STATUS_FILTER_ID,
             type: MUTATION_STATUS_FILTER_TYPE,
-            values: getDefaultMutationStatusFilterValues()
+            values: this.props.mutationStatuses || getDefaultMutationStatusFilterValues()
         }];
 
         if (this.props.cancerTypes) {

--- a/src/pages/Gene.tsx
+++ b/src/pages/Gene.tsx
@@ -13,6 +13,7 @@ interface IGeneProps
 {
     hugoSymbol: string;
     cancerTypes?: string[];
+    mutationStatuses?: string[];
 }
 
 @observer
@@ -55,6 +56,7 @@ class Gene extends React.Component<IGeneProps>
                             data={this.signalMutations}
                             ensemblGene={this.geneStore.ensemblGeneData}
                             cancerTypes={this.props.cancerTypes}
+                            mutationStatuses={this.props.mutationStatuses}
                         />
                 }
             </div>

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -26,6 +26,7 @@ class Main extends React.Component<{}>
             <Gene
                 hugoSymbol={props.match.params.hugoSymbol}
                 cancerTypes={getQueryParamAsArray(props.location, SearchParam.CANCER_TYPE)}
+                mutationStatuses={getQueryParamAsArray(props.location, SearchParam.MUTATION_STATUS)}
             />
         );
 

--- a/src/util/RouterUtils.ts
+++ b/src/util/RouterUtils.ts
@@ -3,6 +3,7 @@ import {parse} from 'query-string';
 
 export enum SearchParam {
     CANCER_TYPE = 'cancerType',
+    MUTATION_STATUS = 'mutationStatus',
     PENETRANCE = 'penetrance',
     HUGO_SYMBOL = 'gene'
 }


### PR DESCRIPTION
Related to #78

- Add gene page links for pathogenic germline and biallelic.
- Add sample counts next to each link (except for biallelic, since the numbers do not always match)

![landscape_plot_tooltip](https://user-images.githubusercontent.com/3604198/103381295-617e3b80-4ab9-11eb-84fa-0bcf8ad587e5.png)
