### PR TITLE
Unregister service workers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script src="unregisterServiceWorkers.js"></script>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-F1EX2C1M11"></script>
   <script>

--- a/public/unregisterServiceWorkers.js
+++ b/public/unregisterServiceWorkers.js
@@ -1,0 +1,10 @@
+// This is to unregister Service Workers registered by previous versions of SignalDB.
+// Simply clearing the cache is not enough to unregister service workers.
+// That's why we need an explicit code to unregister them.
+if (window.navigator && navigator.serviceWorker) {
+    navigator.serviceWorker.getRegistrations().then(function(registrations) {
+        for (let registration of registrations) {
+            registration.unregister();
+        }
+    });
+}


### PR DESCRIPTION
Related to #123

This partially fixes the issue. End users will still need to manually clear the cache to get rid of the cached `index.html`. We may want to look into injecting this code on netlify for a better solution.