### PR TITLE
Update publication link

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -18,7 +18,7 @@ class About extends React.Component<{}>
 
                 <ul>
                     <li>
-                        Srinivasan P, Bandlamudi C, et al. “The context-specific role of germline pathogenicity in tumorigenesis” Nature Genetics <i>in press</i>
+                        <a href='https://www.nature.com/articles/s41588-021-00949-1'>Srinivasan, P., Bandlamudi, C., Jonsson, P. et al. The context-specific role of germline pathogenicity in tumorigenesis. Nat Genet 53, 1577–1585 (2021).</a>
                     </li>
                 </ul>
 


### PR DESCRIPTION
I used the format from Nature Genetics. I'm also aware that cancerhotspot website includes PubMed link too. Let me know whether you also like to have it included for Signal.

## Before
![Screen Shot 2022-11-21 at 12 08 40 PM](https://user-images.githubusercontent.com/5400599/203128922-4b0c9a42-7ad8-495a-94fb-456a19f4b29c.png)

## After
![Screen Shot 2022-11-21 at 12 08 30 PM](https://user-images.githubusercontent.com/5400599/203128904-95d838a6-a7b2-4f4b-9256-49043c9313b8.png)
