### PR TITLE
Add padding around footer

### DIFF
--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -65,7 +65,7 @@ class Main extends React.Component<{}>
                         fluid={true}
                         style={{
                             paddingTop: 20,
-                            paddingBottom: 100,
+                            paddingBottom: 140,
                             color: "#2c3e50"
                         }}
                     >


### PR DESCRIPTION
Footer blocks part of the table after adding citation info. 
![image](https://user-images.githubusercontent.com/16869603/212190435-0daa00c8-10db-421d-8507-9d80d95441da.png)

Add padding between footer and main content.
![image](https://user-images.githubusercontent.com/16869603/212190518-a1acd64f-b4ab-4a67-9893-ef6e12ea7639.png)
